### PR TITLE
Add information about builtin UART serial header

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ It should all just work with any recent release from Fedora/Bazzite etc. However
 - Once enabled you should see a bunch more sensor data reported, including important temps :)
 - Massive thanks to [yeyus](https://github.com/yeyus) for [this info](https://github.com/mothenjoyer69/bc250-documentation/issues/3).
 
+The SuperIO chip also provides a UART port on header J5.
+- Typically available in Linux as `/dev/ttyS0`. (Port 0x3F8, IRQ 4)
+    - Check `sudo dmesg | grep tty` to confirm the device path assignment.
+- Note that RX does not work out of the box because the IRQ does not seem functinal.
+    - To recieve data you must set it to polling mode with `sudo setserial /dev/ttyS0 irq 0` to recieve any data.
+    - This is a CPU hog so only set this when you really need to do serial things (set it back to `irq 4` when you are done)
+
 ## Performance
 - A GPU governor is available [here](https://gitlab.com/mothenjoyer69/oberon-governor). You should use it. Values are set in /etc/oberon-config.yaml.
 - This is also available as a Fedora COPR package [here](https://copr.fedorainfracloud.org/coprs/g/exotic-soc/oberon-governor/).

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This page is for documentation and information on the ASRock/AMD BC-250, and abo
 - Features an AMD BC250 APU, codenamed 'Ariel', a cut-down variant of the APU in the PS5. It integrates 6x Zen 2 cores, at up to 3.49GHz (ish), as well as a 24CU RDNA2 iGPU (Codename 'cyan-skillfish'). The standard PS5 SoC has 36CUs.
 - 1x M.2 2280 slot with support for NVMe (PCIe 2.0 x2) and SATA 3
 - 1x DisplayPort, 1x GbE Ethernet, 2x USB 2.0, 2x USB 3.0
-- 1x SPI header, 1x auto-start jumper, 1x clear CMOS jumper, 5x fans (non-standard connector), 1x TPM header
-- NCT6686 SuperIO chip, with a UART port mapped to header J5.
+- 1x SPI header, 1x UART header, 1x auto-start jumper, 1x clear CMOS jumper, 5x fans (non-standard connector), 1x TPM header
+- NCT6686 SuperIO chip
 - 220W TDP, so make sure you have a good quality power supply with PCIe 8-pin connectors available and a plan for cooling it. You can, in a pinch, get away with directly placing two 120mm fans directly on top of the heatsink. If you are doing custom cooling, don't forget the memory!!! Its GDDR6 it runs really hot!!!!
 
 ## Hardware Details

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The SuperIO chip also provides a UART port on header J5.
 - Typically available in Linux as `/dev/ttyS0`. (Port 0x3F8, IRQ 4)
     - Check `sudo dmesg | grep tty` to confirm the device path assignment.
 - Note that RX does not work out of the box because the IRQ does not seem functinal.
-    - To recieve data you must set it to polling mode with `sudo setserial /dev/ttyS0 irq 0` to recieve any data.
+    - To recieve data you must set it to polling mode with `sudo setserial /dev/ttyS0 irq 0`
     - This is a CPU hog so only set this when you really need to do serial things (set it back to `irq 4` when you are done)
 
 ## Performance

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This page is for documentation and information on the ASRock/AMD BC-250, and abo
 - 1x M.2 2280 slot with support for NVMe (PCIe 2.0 x2) and SATA 3
 - 1x DisplayPort, 1x GbE Ethernet, 2x USB 2.0, 2x USB 3.0
 - 1x SPI header, 1x auto-start jumper, 1x clear CMOS jumper, 5x fans (non-standard connector), 1x TPM header
-- NCT6686 SuperIO chip
+- NCT6686 SuperIO chip, with a UART port mapped to header J5.
 - 220W TDP, so make sure you have a good quality power supply with PCIe 8-pin connectors available and a plan for cooling it. You can, in a pinch, get away with directly placing two 120mm fans directly on top of the heatsink. If you are doing custom cooling, don't forget the memory!!! Its GDDR6 it runs really hot!!!!
 
 ## Hardware Details

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ It should all just work with any recent release from Fedora/Bazzite etc. However
 The SuperIO chip also provides a UART port on header J5.
 - Typically available in Linux as `/dev/ttyS0`. (Port 0x3F8, IRQ 4)
     - Check `sudo dmesg | grep tty` to confirm the device path assignment.
-- Note that RX does not work out of the box because the IRQ does not seem functinal.
+- Note that RX does not work out of the box because the IRQ does not seem functional.
     - To recieve data you must set it to polling mode with `sudo setserial /dev/ttyS0 irq 0`
     - This is a CPU hog so only set this when you really need to do serial things (set it back to `irq 4` when you are done)
 

--- a/hardware.md
+++ b/hardware.md
@@ -34,6 +34,28 @@ The SCL pin is on the "lower" side of the board, closer to the power connectors.
 
 This exposes an I2C interface which appears to host PMBUS communications to the Intersil PMICs.
 
+## SPERAKER1 / J5
+
+```
+[  -   -   -   -  ]
+[ 3V3 GND RX  TX  ]
+   ^
+```
+
+The unpopulated header J5 exposes a UART serial port provided by the SuperIO chip.
+Note that J5 is the lower row, under SPEAKER1.
+
+* TX: 3.3V signal.
+* RX: Tolerates TTL according to datasheet.
+
+Typically available in Linux as `/dev/ttyS0`. (Port 0x3F8, IRQ 4)
+Check `sudo dmesg | grep tty` to find confirm the device path assignment.
+
+
+Note that the RX IRQ does not seem to be working correctly,
+so you must use set it to polling mode with `sudo setserial /dev/ttyS0 irq 0` to recieve any data.
+This is a CPU hog so only set this when you really need to do serial things (set it back to `irq 4` when you are done)
+
 ## J4003
 
 ```

--- a/hardware.md
+++ b/hardware.md
@@ -49,7 +49,7 @@ Note that J5 is the lower row, under SPEAKER1.
 * RX: Tolerates TTL according to datasheet.
 
 Typically available in Linux as `/dev/ttyS0`. (Port 0x3F8, IRQ 4)
-Check `sudo dmesg | grep tty` to find confirm the device path assignment.
+Check `sudo dmesg | grep tty` to confirm the device path assignment.
 
 
 Note that the RX IRQ does not seem to be working correctly,

--- a/hardware.md
+++ b/hardware.md
@@ -34,7 +34,7 @@ The SCL pin is on the "lower" side of the board, closer to the power connectors.
 
 This exposes an I2C interface which appears to host PMBUS communications to the Intersil PMICs.
 
-## SPERAKER1 / J5
+## SPEAKER1 / J5
 
 ```
 [  -   -   -   -  ]

--- a/hardware.md
+++ b/hardware.md
@@ -46,7 +46,7 @@ The unpopulated header J5 exposes a UART serial port provided by the SuperIO chi
 Note that J5 is the lower row, under SPEAKER1.
 
 * TX: 3.3V signal.
-* RX: Tolerates TTL according to datasheet.
+* RX: Tolerates 5V / TTL according to datasheet.
 
 ## J4003
 

--- a/hardware.md
+++ b/hardware.md
@@ -48,14 +48,6 @@ Note that J5 is the lower row, under SPEAKER1.
 * TX: 3.3V signal.
 * RX: Tolerates TTL according to datasheet.
 
-Typically available in Linux as `/dev/ttyS0`. (Port 0x3F8, IRQ 4)
-Check `sudo dmesg | grep tty` to confirm the device path assignment.
-
-
-Note that the RX IRQ does not seem to be working correctly,
-so you must use set it to polling mode with `sudo setserial /dev/ttyS0 irq 0` to recieve any data.
-This is a CPU hog so only set this when you really need to do serial things (set it back to `irq 4` when you are done)
-
 ## J4003
 
 ```


### PR DESCRIPTION
It turns out that the unpopulated J5 header exposes a UART port provided by the SuperIO controller, and it is usable from Linux.
So, the BC-250 has a built in conveniently accessible UART port.

Included in the PR are details for using it in Linux.

Sorry for having lots of typo commits, feel free to squash merge

<img width="1134" height="687" alt="uart" src="https://github.com/user-attachments/assets/978eb379-0e2e-49fd-ab1b-b209437389b7" />
